### PR TITLE
Add ChimeraX visualization support (fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the most recent version of 3DFSC, by Philip Baldwin, Yong Zi Tan, and Dm
 
 GPU code and Conda environment by Carl Negro.
 
-3DFSC Program Suite requires Miniconda 3 to run, and UCSF Chimera to visualize the outputs.
+3DFSC Program Suite requires Miniconda 3 to run, and UCSF Chimera or ChimeraX to visualize the outputs.
 
 **Important: this version of the software has been modified to work with updated dependencies (October 2023). I have tested it with cudatoolkit 11.8**
 
@@ -18,6 +18,35 @@ GPU code and Conda environment by Carl Negro.
 ## Execution ##
 
 To view the 3DFSC parameters, access the help info like `ThreeDFSC/ThreeDFSC_Start.py -h`.
+
+**Important notes:**
+- The `--apix` parameter is **required** and must be set to the correct pixel size of your map. The default value of 1.0 is incorrect and should not be used.
+- Use `--viewer` to specify the visualization tool: `chimera` (default) or `chimerax`.
+
+**Example 1: Using Chimera (default viewer)**
+```bash
+python ThreeDFSC/ThreeDFSC_Start.py \
+--halfmap1 <path_to_halfmap1.mrc> \
+--halfmap2 <path_to_halfmap2.mrc> \
+--fullmap <path_to_fullmap.mrc> \
+--mask <path_to_mask.mrc> \
+--ThreeDFSC <output_directory> \
+--gpu \
+--apix <pixel_size>
+```
+
+**Example 2: Using ChimeraX**
+```bash
+python ThreeDFSC/ThreeDFSC_Start.py \
+--halfmap1 <path_to_halfmap1.mrc> \
+--halfmap2 <path_to_halfmap2.mrc> \
+--fullmap <path_to_fullmap.mrc> \
+--mask <path_to_mask.mrc> \
+--ThreeDFSC <output_directory> \
+--gpu \
+--apix <pixel_size> \
+--viewer chimerax
+```
 
 ## GPU Execution ##
 

--- a/ThreeDFSC/ThreeDFSC_Start.py
+++ b/ThreeDFSC/ThreeDFSC_Start.py
@@ -163,7 +163,7 @@ def execute(options):
     ThreeDFSC_Analysis.main(halfmap1, halfmap2, fullmap, options.apix, options.ThreeDFSC, options.dthetaInDegrees,
                             options.histogram, options.FSCCutoff,
                             options.ThresholdForSphericity, options.HighPassFilter,
-                            options.numThresholdsForSphericityCalcs, options.gpu)
+                            options.numThresholdsForSphericityCalcs, options.gpu, viewer=options.viewer)
     print("\nDone")
     print("Results are in the folder Results_" + str(options.ThreeDFSC))
     print("--- %s seconds ---" % (time.time() - start_program_time))
@@ -226,6 +226,10 @@ if __name__ == '__main__':
     parser.add_option("--gpu_id", dest="gpu_id", action="store", type="int", default=False,
                       help="If using GPU, specify the device id to use like '--gpu_id=1'. Select only one device (no multi-GPU support).",
                       metavar="INT")
+
+    parser.add_option("--viewer", dest="viewer", action="store", type="string", default="chimera",
+                  help="Viewer to use for visualization: 'chimera' or 'chimerax'. Default is 'chimera'.",
+                  metavar="STRING")
     (options, args) = parser.parse_args()
     print("\n*******************************************\n")
     print("Running 3DFSC with the following parameters:\n")

--- a/ThreeDFSC/programs/ChimeraX/3DFSCPlot_ChimeraX_Template.cxc
+++ b/ThreeDFSC/programs/ChimeraX/3DFSCPlot_ChimeraX_Template.cxc
@@ -1,0 +1,30 @@
+# Display 3DFSC and color original map by angular resolution (ChimeraX version)
+
+# Load the ChimeraX python script that registers the "fscplot" command
+open lineplot.py
+
+# Background
+set bgColor white
+
+# Open both volumes (update paths as needed)
+open #===3DFSC====#
+volume #1 originIndex #==Origin3DFSC==#
+volume #1 voxelSize #==apix==#
+
+open #===FullMap====#
+volume #2 originIndex #==OriginFullMap==#
+volume #2 voxelSize #==apix==#
+
+# Hide the 3DFSC volume; keep original density visible
+hide #1
+
+# Fit view
+view
+
+# Draw the color key
+# Use "Times New Roman" font if available
+key red:Poorer blue:Better pos 0.20,0.10 size 0.6,0.04 ticks true tickThickness 3 labelColor black
+2dlabels create Label text "Relative XY-plane resolution (AU)" color black xpos 0.20 ypos 0.16
+
+# Execute fsc plot; use #1 to calculate ray values, then color #2
+fscplot #1

--- a/ThreeDFSC/programs/ChimeraX/lineplot_template.py
+++ b/ThreeDFSC/programs/ChimeraX/lineplot_template.py
@@ -1,0 +1,174 @@
+# -----------------------------------------------------------------------------
+# Make a matplotlib plot of density values along a ray from center of a map.
+# Use the current view direction and update plot as view changes.
+#
+# This script registers command "fscplot" which takes one argument, the density
+# map for which the plot is made.  For example,
+#
+#    fscplot #1
+#
+# (Ported from UCSF Chimera to UCSF ChimeraX with minimal changes.)
+# Original template content: /mnt/data/lineplot_template.py
+# -----------------------------------------------------------------------------
+
+def ray_values(v, direction):
+    d = v.data
+    center = [0.5*(s+1) for s in d.size]
+    radius = 0.5*min([s*t for s,t in zip(d.size, d.step)])
+    steps = max(d.size)
+    from numpy import array, arange, float32, outer
+    # direction should be a 3-vector
+    dn = (direction[0]**2 + direction[1]**2 + direction[2]**2) ** 0.5
+    if dn == 0:
+        dn = 1.0
+    dir = array(direction, dtype=float32) / dn
+    radii = arange(0, steps, dtype=float32) * (radius/steps)
+    ray_points = outer(radii, dir)
+    values = v.interpolated_values(ray_points)
+    return radii, values, radius
+
+# -----------------------------------------------------------------------------
+#
+def plot(x, y, xlabel, ylabel, title, fig=None):
+    import matplotlib.pyplot as plt
+    global_x = #==global_x==#
+    global_y = #==global_y==#
+    if fig is None:
+        fig = plt.figure()
+        fig.plot = ax = fig.add_subplot(1,1,1)
+    else:
+        ax = fig.plot
+        ax.clear()
+    plt.subplots_adjust(top=0.85)
+    ax.plot(x, y, color='tab:blue', linewidth=2.0)
+    ax.plot(global_x, global_y, 'tab:orange', linewidth=1.0)  # Plot global FSC
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_ylim(ymin=-0.2, ymax=1.01)
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3, linestyle='-', linewidth=0.8, color='gray')
+    ax.set_axisbelow(True)
+    # Show / update window
+    fig.canvas.manager.show()
+    fig.canvas.draw_idle()
+    return fig
+
+# -----------------------------------------------------------------------------
+#
+def _view_direction_in_map_coords(session, fsc_map):
+    """
+    Return the current camera view direction expressed in the map's local coordinates.
+    We try the common ChimeraX camera APIs, with a safe fallback.
+    """
+    # camera view direction in scene coords (pointing "into" the screen)
+    cam = session.main_view.camera
+    vd = None
+    for attr in ('view_direction', 'viewDirection'):
+        if hasattr(cam, attr):
+            try:
+                vd = getattr(cam, attr)()
+                break
+            except TypeError:
+                vd = getattr(cam, attr)
+                break
+    if vd is None:
+        # Fallback: in ChimeraX, camera looks down -Z in its own coords.
+        vd = (0.0, 0.0, -1.0)
+
+    # Convert scene -> model coords if possible
+    try:
+        # fsc_map.position is a Place (scene transform of the model)
+        # Place multiplication usually supports tuples/vectors.
+        vd_map = fsc_map.position.inverse() * vd
+        return (vd_map[0], vd_map[1], vd_map[2])
+    except Exception:
+        return (vd[0], vd[1], vd[2])
+
+# -----------------------------------------------------------------------------
+#
+def update_plot(session, fsc_map, fig=None):
+    direction = _view_direction_in_map_coords(session, fsc_map)
+    preradii, values, radius = ray_values(fsc_map, direction)
+
+    radii = []
+    apix = #==apix==#
+    resolution_list = []
+    for i in range(len(preradii)):
+        radii.append(preradii[i]/(radius*2*apix))
+    for i in range(len(values)):
+        if values[i] < 0.143:
+            resolution_list.append(1/radii[i-1])
+            break
+    resolution = resolution_list[0] if resolution_list else float('inf')
+
+    title = ('3D FSC Plot.\n'
+             'Z directional resolution (out-of-plane in blue) is %.2f.\n'
+             'Global resolution (in orange) is %.2f.'
+             % (resolution, #==global_res==#))
+    fig = plot(radii, values, xlabel='Spatial Resolution',
+               ylabel='Correlation', title=title, fig=fig)
+    color_map(session, resolution)
+    return fig
+
+# -----------------------------------------------------------------------------
+#
+def _rgba_cmd_from_float01(r, g, b, a=1.0):
+    # clip
+    r = 0.0 if r < 0 else 1.0 if r > 1 else r
+    g = 0.0 if g < 0 else 1.0 if g > 1 else g
+    b = 0.0 if b < 0 else 1.0 if b > 1 else b
+    a = 0.0 if a < 0 else 1.0 if a > 1 else a
+    # convert to 0-255 range for rgba() format
+    R, G, B, A = (int(round(255*x)) for x in (r, g, b, a))
+    return f"rgba({R},{G},{B},{A})"
+
+def color_map(session, resolution):
+    from chimerax.core.commands import run
+    maxres = #==maxres==#
+    minres = #==minres==#
+    a = (resolution-maxres)/(minres-maxres)
+    r, g, b = 1-a, 0.0, a
+    run(session, f"color #2 {_rgba_cmd_from_float01(r,g,b,a)}")
+
+# -----------------------------------------------------------------------------
+#
+def fsc_plot(session, fsc_map):
+    fig = update_plot(session, fsc_map)
+
+    # Update whenever a new frame is drawn (captures view rotations).
+    # ChimeraX well-known triggers include "frame drawn".  The trigger data is
+    # an UpdateLoop instance (not needed here).
+    state = {'last_cam_pos': None}
+
+    def motion_cb(trigger_name, update_loop):
+        # Throttle updates: only redraw if camera pose changed
+        cam_pos = getattr(session.main_view.camera, 'position', None)
+        if cam_pos is not None:
+            if state['last_cam_pos'] is not None and cam_pos == state['last_cam_pos']:
+                return
+            state['last_cam_pos'] = cam_pos
+        update_plot(session, fsc_map, fig)
+
+    h = session.triggers.add_handler('frame drawn', motion_cb)
+    # Store handler on model to keep it alive and allow user to remove if desired.
+    fsc_map._fscplot_handler = h
+
+# -----------------------------------------------------------------------------
+# Command registration (ChimeraX)
+#
+def fscplot_cmd(session, fscMap):
+    # Accept either a single map or a list of maps (MapsArg)
+    if isinstance(fscMap, (list, tuple)):
+        if len(fscMap) == 0:
+            return
+        fscMap = fscMap[0]
+    fsc_plot(session, fscMap)
+
+def register_command(session):
+    from chimerax.core.commands import CmdDesc, register
+    # MapsArg is used in official recipes, and works for volume models.
+    from chimerax.map import MapsArg
+    desc = CmdDesc(required=[('fscMap', MapsArg)])
+    register('fscplot', desc, fscplot_cmd, logger=session.logger)
+
+register_command(session)

--- a/ThreeDFSC/programs/ThreeDFSC_Analysis.py
+++ b/ThreeDFSC/programs/ThreeDFSC_Analysis.py
@@ -46,6 +46,26 @@ from scipy.ndimage.filters import gaussian_filter
 import cuda_functions
 
 
+VIEWER_CONFIG = {
+    'chimera': {
+        'output_dir': 'Chimera',
+        'cmd_file': '3DFSCPlot_Chimera.cmd',
+        'template_cmd': '3DFSCPlot_Chimera_Template.cmd'
+    },
+    'chimerax': {
+        'output_dir': 'ChimeraX',
+        'cmd_file': '3DFSCPlot_ChimeraX.cxc',
+        'template_cmd': '3DFSCPlot_ChimeraX_Template.cxc'
+    }
+}
+
+
+def get_viewer_config(viewer):
+    if viewer not in VIEWER_CONFIG:
+        raise ValueError("Invalid viewer: %s. Supported viewers: %s" % (viewer, ', '.join(VIEWER_CONFIG.keys())))
+    return VIEWER_CONFIG[viewer]
+
+
 def cartesian_to_spherical(vector):
     """Convert the Cartesian vector [x, y, z] to spherical coordinates [r, theta, phi].
 
@@ -466,9 +486,14 @@ def HistogramCreation(histogram_sampling, histogram, ThreeDFSC, apix, cutoff, sp
     return 1 / float(max(histogramlist)), 1 / float(min(histogramlist)), globalspatialfrequency, globalfsc
 
 
-def ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialfrequency, globalfsc, global_resolution):
+def ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialfrequency, globalfsc, global_resolution, viewer='chimera'):
+    config = get_viewer_config(viewer)
+    template_dir = config['output_dir']
+    cmd_file = config['cmd_file']
+    template_cmd = config['template_cmd']
+    
     ## Generate Lineplot.py File
-    with open(os.path.realpath(__file__)[:-21] + "Chimera/lineplot_template.py") as f:
+    with open(os.path.realpath(__file__)[:-21] + template_dir + "/lineplot_template.py") as f:
         replaced1 = f.read().replace("#==apix==#", str(apix))
         replaced2 = replaced1.replace("#==maxres==#", str(maxRes))
         replaced3 = replaced2.replace("#==minres==#", str(minRes))
@@ -476,13 +501,13 @@ def ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialf
         replaced5 = replaced4.replace("#==global_y==#", str(globalfsc))
         replaced6 = replaced5.replace("#==global_res==#", str(global_resolution))
 
-    with open("Results_" + str(ThreeDFSC) + "/Chimera/lineplot.py", "w") as f:
+    with open("Results_" + str(ThreeDFSC) + "/" + template_dir + "/lineplot.py", "w") as f:
         f.write(replaced6)
 
     ## Obtain origins for maps
 
     # read MRCS
-    input3DFSC = (mrcfile.open("Results_" + str(ThreeDFSC) + "/Chimera/" + ThreeDFSC + ".mrc")).data
+    input3DFSC = (mrcfile.open("Results_" + str(ThreeDFSC) + "/" + template_dir + "/" + ThreeDFSC + ".mrc")).data
     inputFullMap = (mrcfile.open(fullmap)).data  # Full maps can be anywhere
 
     # coordinates
@@ -492,15 +517,14 @@ def ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialf
         int(inputFullMap.shape[2] / 2))
 
     ## 3DFSCPlot_Chimera.cmd File
-
-    with open(os.path.realpath(__file__)[:-21] + "Chimera/3DFSCPlot_Chimera_Template.cmd") as f:
+    with open(os.path.realpath(__file__)[:-21] + template_dir + "/" + template_cmd) as f:
         replaced1 = f.read().replace("#===3DFSC====#", str(os.path.basename(ThreeDFSC)) + ".mrc")
         replaced2 = replaced1.replace("#==apix==#", str(apix))
         replaced3 = replaced2.replace("#==Origin3DFSC==#", str(center3DFSC))
         replaced4 = replaced3.replace("#==OriginFullMap==#", str(centerFullMap))
         replaced5 = replaced4.replace("#===FullMap====#", str(os.path.basename(fullmap)))
 
-    with open("Results_" + str(ThreeDFSC) + "/Chimera/3DFSCPlot_Chimera.cmd", "w") as f:
+    with open("Results_" + str(ThreeDFSC) + "/" + template_dir + "/" + cmd_file, "w") as f:
         f.write(replaced5)
 
 
@@ -550,7 +574,7 @@ def calc_threshold_ranges(numThresholdsForSphericityCalcs, FSCCutoff):
 
 
 def main(halfmap1, halfmap2, fullmap, apix, ThreeDFSC, dthetaInDegrees, histogram, FSCCutoff, ThresholdForSphericity,
-         HighPassFilter, numThresholdsForSphericityCalcs, gpu=False):
+         HighPassFilter, numThresholdsForSphericityCalcs, gpu=False, viewer='chimera'):
     # Part 00
     # Warnings and checks. Invisible to user unless something is wrong
     global_resolution = check_globalFSC(ThreeDFSC, apix)
@@ -589,16 +613,20 @@ def main(halfmap1, halfmap2, fullmap, apix, ThreeDFSC, dthetaInDegrees, histogra
     print("Results_" + ThreeDFSC + "/" + histogram + ".pdf generated.")
 
     # Part 05
-    click.echo(click.style("\nAnalysis Step 04: Generating Output Files for Chimera Viewing of 3DFSC", fg="blue"))
-    os.system("mkdir Results_" + str(ThreeDFSC) + "/Chimera")
+    config = get_viewer_config(viewer)
+    output_dir = config['output_dir']
+    cmd_file_name = config['cmd_file']
+    
+    click.echo(click.style("\nAnalysis Step 04: Generating Output Files for %s Viewing of 3DFSC" % output_dir, fg="blue"))
+    os.system("mkdir Results_" + str(ThreeDFSC) + "/" + output_dir)
     os.system(
-        "cp Results_" + str(ThreeDFSC) + "/" + str(ThreeDFSC) + ".mrc " + " Results_" + str(ThreeDFSC) + "/Chimera/")
-    os.system("cp " + fullmap + " Results_" + str(ThreeDFSC) + "/Chimera/")
-    ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialfrequency, globalfsc, global_resolution)
-    print("Results_" + str(ThreeDFSC) + "/Chimera/3DFSCPlot_Chimera.cmd and Results_" + str(
-        ThreeDFSC) + "/Chimera/lineplot.py generated.")
+        "cp Results_" + str(ThreeDFSC) + "/" + str(ThreeDFSC) + ".mrc " + " Results_" + str(ThreeDFSC) + "/" + output_dir + "/")
+    os.system("cp " + fullmap + " Results_" + str(ThreeDFSC) + "/" + output_dir + "/")
+    ChimeraOutputCreate(ThreeDFSC, apix, maxRes, minRes, fullmap, globalspatialfrequency, globalfsc, global_resolution, viewer=viewer)
+    print("Results_" + str(ThreeDFSC) + "/" + output_dir + "/" + cmd_file_name + " and Results_" + str(
+        ThreeDFSC) + "/" + output_dir + "/lineplot.py generated.")
     print(
-        "To view in Chimera, open 3DFSCPlot_Chimera.cmd in Chimera, with lineplot.py and the mrc files in the Chimera folder in the same directory.")
+        "To view in %s, open %s in %s, with lineplot.py and the mrc files in the %s folder in the same directory." % (output_dir, cmd_file_name, output_dir, output_dir))
 
     # Part 06
     # Optionally, calculate sphericities across multiple thresholds to determine the deviation from the mean


### PR DESCRIPTION
## Summary

Adds ChimeraX visualization support to address #1. Users can now use either Chimera (default) or ChimeraX via the `--viewer` parameter.

## Changes

- Added `--viewer` parameter supporting `chimera` and `chimerax`
- Created ChimeraX template files and updated analysis module
- Updated README.md with ChimeraX usage examples

## Testing

Tested on macOS with ChimeraX 1.8 and 1.9. Working correctly.
